### PR TITLE
Adding clang-tidy format checking support

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Disable clang-tidy for 3rdparty directories
+set(CMAKE_CXX_CLANG_TIDY "")
+
+# Add 3rdparty components
+add_subdirectory(${THIRDPARTY_DIR}/SDL)
+add_subdirectory(${THIRDPARTY_DIR}/libconfig)
+add_subdirectory(${THIRDPARTY_DIR}/spdlog)
+add_subdirectory(${THIRDPARTY_DIR}/soci)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,11 +43,8 @@ set(SOCI_ORACLE OFF CACHE BOOL "" FORCE)
 set(SOCI_POSTGRESQL OFF CACHE BOOL "" FORCE)
 set(SOCI_DB2 OFF CACHE BOOL "" FORCE)
 
-# Add 3rdparty components
-add_subdirectory(${THIRDPARTY_DIR}/SDL)
-add_subdirectory(${THIRDPARTY_DIR}/libconfig)
-add_subdirectory(${THIRDPARTY_DIR}/spdlog)
-add_subdirectory(${THIRDPARTY_DIR}/soci)
+# Add 3rdparty directory
+add_subdirectory(${THIRDPARTY_DIR})
 
 configure_file(include/althack/config.hpp.in include/althack/config.hpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,9 @@ set(THIRDPARTY_DIR ${PROJECT_SOURCE_DIR}/3rdparty)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
+# clang settings
+set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=*,-modernize-use-trailing-return-type,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-fuchsia-default-arguments-calls,-fuchsia-statically-constructed-objects")
+
 # Project subdirectories
 add_subdirectory("docs")
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,3 +33,5 @@ There is a [list of issues](https://github.com/althack-project/althack/issues) o
 ## Styleguide
 
 The project has a style very similar to that of the [Google C++ Styleguide](https://google.github.io/styleguide/cppguide.html). If you feel something is off or does not make sense, feel free to flag it via [email](mailto:contact@althack-game.com) or [open a discussion](https://github.com/althack-project/althack/discussions)! I'm working on adding clang support to the build chain to enforce certain rules - but until then, use good judgement, look at the already existing code, and ask if something isn't crystal clear!
+
+I many cases, clang-tidy should catch the most common issues and guide you through correct code formatting and syntax essentials. If you think that the clang-tidy config needs improvement, feel free to propose a change.

--- a/include/althack/althack.hpp
+++ b/include/althack/althack.hpp
@@ -44,7 +44,7 @@ class AltHack {
   // ...
   bool teardown();
 
-  std::string getVersion() const;
+  static std::string getVersion();
 
   void setHeadless(bool headless);
 

--- a/include/althack/database.hpp
+++ b/include/althack/database.hpp
@@ -19,7 +19,7 @@ class Database {
   virtual bool close() = 0;
 
  protected:
-  std::string getISO8601Timestamp() const;
+  static std::string getISO8601Timestamp();
 };
 
 }  // namespace althack

--- a/src/althack/althack.cpp
+++ b/src/althack/althack.cpp
@@ -71,7 +71,7 @@ bool AltHack::teardown() {
   return true;
 }
 
-std::string AltHack::getVersion() const {
+std::string AltHack::getVersion() {
   return
     std::to_string(AH_MAJOR_VERSION) + "." +
     std::to_string(AH_MINOR_VERSION) + "." +

--- a/src/althack/backends/server_backend.cpp
+++ b/src/althack/backends/server_backend.cpp
@@ -11,8 +11,8 @@ ServerBackend::ServerBackend(const std::string& database_file)
   database_ = std::make_unique<databases::SociDatabase>(database_file);
   database_->open();
 
-  accounts_cache_.push_back(visuals::AccountNode("node1", "rainforest", "acc123", 100.0, "$"));
-  accounts_cache_.push_back(visuals::AccountNode("node2", "paybuddy", "acc@pb.domain", 52.75, "EUR"));
+  accounts_cache_.emplace_back("node1", "rainforest", "acc123", 100.0, "$");
+  accounts_cache_.emplace_back("node2", "paybuddy", "acc@pb.domain", 52.75, "EUR");
 }
 
 ServerBackend::~ServerBackend() {

--- a/src/althack/database.cpp
+++ b/src/althack/database.cpp
@@ -2,17 +2,18 @@
 
 // Standard
 #include <chrono>
+#include <cstdint>
 #include <ctime>
 #include <iomanip>
 #include <sstream>
 
 namespace althack {
 
-std::string Database::getISO8601Timestamp() const {
+std::string Database::getISO8601Timestamp() {
   const auto now = std::chrono::system_clock::now();
   const std::time_t time = std::chrono::system_clock::to_time_t(now);
   const std::tm* now_tm = std::localtime(&time);
-  const int64 timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+  const int64_t timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
 
   std::stringstream sts;
   sts << std::setfill('0')

--- a/src/althack/database.cpp
+++ b/src/althack/database.cpp
@@ -1,7 +1,8 @@
 #include <althack/database.hpp>
 
-#include <ctime>
+// Standard
 #include <chrono>
+#include <ctime>
 #include <iomanip>
 #include <sstream>
 
@@ -11,7 +12,7 @@ std::string Database::getISO8601Timestamp() const {
   const auto now = std::chrono::system_clock::now();
   const std::time_t time = std::chrono::system_clock::to_time_t(now);
   const std::tm* now_tm = std::localtime(&time);
-  const long long timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+  const int64 timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
 
   std::stringstream sts;
   sts << std::setfill('0')

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,7 @@ void signal_handler(int signal) { shutdown_handler(signal); }
 }  // namespace
 
 int main(int argc, char** argv) {
-  std::string config_path = "";
+  std::string config_path;
   bool headless = false;
 
   althack::AltHack instance;
@@ -71,7 +71,7 @@ int main(int argc, char** argv) {
   }
 
   std::signal(SIGINT, signal_handler);
-  shutdown_handler = [&](int signal) { instance.stop(); };
+  shutdown_handler = [&](int /*signal*/) { instance.stop(); };
 
   spdlog::info("Ready, entering main loop");
   if (instance.run()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char** argv) {
 
   // Parse command line options
   try {
-    TCLAP::CmdLine cmd("AltHack command line", ' ', instance.getVersion());
+    TCLAP::CmdLine cmd("AltHack command line", ' ', althack::AltHack::getVersion());
 
     TCLAP::ValueArg<std::string> config_path_arg(
         "c", "config", "Path of configuration file to use", false, "", "path");
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
     config_path = "../configs/default.cfg";
   }
 
-  spdlog::info("Instantiating AltHack (version " + instance.getVersion() + ")");
+  spdlog::info("Instantiating AltHack (version " + althack::AltHack::getVersion() + ")");
   instance.setHeadless(headless);
 
   if (headless) {


### PR DESCRIPTION
The build chain now includes clang-tidy support.